### PR TITLE
Fixes webwallet btn alignment on small screens

### DIFF
--- a/assets/_scss/_main.scss
+++ b/assets/_scss/_main.scss
@@ -481,21 +481,21 @@ div.download {
     @include breakpoint-s {width: auto;}
   }
 }
+
 div.webwallet {
-
-  text-align: center;
   margin-top: (1.5*$spacing);
-  @include breakpoint-s { margin-top: (3*$spacing); }
+  text-align: center;
+  @include breakpoint-s {margin-top: (3*$spacing);}
 
   a.button {
-    display: inline-block;
-    vertical-align: middle;
-    margin: 5px 10px;
-  }
-  a.button {
-    width: 100%;
-    margin-top: (1.5*$spacing);
-    @include breakpoint-s {width: auto; margin-top: 5px;}
+    display: block;
+    margin: (1.5*$spacing) 0 0;
+
+    @include breakpoint-s {
+      display: inline-block;
+      vertical-align: middle;
+      margin: 0 1rem;
+    }
   }
 }
 


### PR DESCRIPTION
The buttons were slightly misaligned as in image below. This CSS will fix it.

![screen shot 2019-01-09 at 12 02 14](https://user-images.githubusercontent.com/23356013/50898298-aad5ac00-1406-11e9-8be9-8d4ee3e7dbf0.PNG)

